### PR TITLE
Docs: Refine Docs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,12 +2,13 @@ name: Test Services
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
     branches-ignore:
       - master
-      - feat/game-demo
   pull_request:
     paths-ignore:
-      - 'Makefile'
       - '**.md'
       - 'docs/**'
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Got more idea on how to make this learning project more fun? Or maybe you found 
 
 Feel free to contribute to this repo by opening issue or creating a pull request! 😃
 
+## Core Maintainers
+
+- [Riandy Rahman Nugraha (@riandyrn)](https://github.com/riandyrn)
+- [Muhammad Iskandar Dzulqornain (@isdzulqor)](https://github.com/isdzulqor)
+- [Muhammad Izzuddin al Fikri (@knightazura)](https://github.com/knightazura)
+- [Alfat Saputra Harun (@harunalfat)](https://github.com/harunalfat)
+- [Ilham Syahid Syamsudin (@ilhamsyahids)](https://github.com/ilhamsyahids)
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is the flowchart for each battle in the game:
     <img src="./docs/reference/assets/battle-flow.drawio.svg" alt="Battle Flow" height="400" />
 </p>
 
-To see the REST API specification for this game, please see [this doc](./docs/api-design/rest-api.md).
+To see the REST API specification for this game, please see [this doc](./docs/api/rest-api.md).
 
 ## How to Run The Game
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ In this repo you will learn about Haraj Solutions Team's secret technique in wri
 
 The secret technique actually lies in the software architecture we choose for these projects: [Hexagonal Architecture](./docs/reference/hex-architecture.md).
 
-In this repo we will share to you our knowledge on this special architecture through simple server-client game named `Hex Monscape`.
-
-We are using [Hexagonal Architecture](./docs/reference/hex-architecture.md) to build `Hex Monscape` game server while coding it using [Go](https://go.dev/). As for the web client, we code it using [Vue 3](https://vuejs.org/).
+In this repo we will share to you our knowledge on this special architecture through simple server-client game named `Hex Monscape`. We are using [Hexagonal Architecture](./docs/reference/hex-architecture.md) to build the game server while coding it using [Go](https://go.dev/) & for the web client we code it using [Vue 3](https://vuejs.org/).
 
 To understand how we apply [Hexagonal Architecture](./docs/reference/hex-architecture.md) to this game, please refer to [this doc](./docs/reference/hex-architecture.md).
 
@@ -16,11 +14,11 @@ To start playing the game, please refer to [How to Run The Game](#how-to-run-the
 
 > **Note:**
 >
-> As Solutions Team member, your understanding towards [Hexagonal Architecture](./docs/reference/hex-architecture.md) is mandatory since it is the main architecture we used for building Haraj production services.
+> As Solutions Team member, your understanding towards [Hexagonal Architecture](./docs/reference/hex-architecture.md) is mandatory since it is the default architecture we used for building Haraj production services.
 >
 > So if you understand this architecture well, you will be in no time contributing to Haraj production.
 >
-> Also notice that even though here we are using Go as an example to showcase [Hexagonal Architecture](./docs/reference/hex-architecture.md), but actually this architecture is language agnostic. So you could apply it to any programming language you want.
+> Also notice that even though in this repo we are using Go to implement [Hexagonal Architecture](./docs/reference/hex-architecture.md), but actually this architecture is language agnostic. So you could apply it to other language as well such as PHP, Typescript, & Python.
 
 ## Background Story
 
@@ -30,7 +28,7 @@ What is code maintainability? Essentially it is the ability of a codebase to be 
 
 In the early days of Haraj, we used to assign project ownership to a single developer. So every developer in the team will own at least one project. However we made a mistake by not setting up common standards on how to write code in Haraj. So every developers in the team wrote code based on their own style & preference.
 
-Usually our developers will stay for quite a long time (~5 years) before they left. So when a developer left the team, usually he/she already owned several projects that valuable for Haraj business. The problem is since the projects written by the developer's own style, no one in the team could easily take over those projects. 😅
+Usually our developers will stay for quite a long time (`~5 years`) before they left. So when a developer left the team, usually he/she already owned several projects that valuable for Haraj business. The problem is since the projects written by the developer's own style, no one in the team could easily take over those projects. 😅
 
 <p align="center">
     <img width=512 src="./docs/reference/assets/memes/code-maintainability-this-is-fine.jpg" alt="Code Maintainability? This is fine.">
@@ -62,7 +60,11 @@ To see the REST API specification for this game, please see [this doc](./docs/ap
 
 You can try out this game online by visiting this URL: https://hex-monscape.haraj.app.
 
-If you want to run the game locally, make sure [make](https://linuxhint.com/make-command-linux/) & [Docker](https://docs.docker.com/get-docker/) `v20.10.23` or above already installed in your machine. Make sure also you already has [Docker Compose](https://docs.docker.com/compose/install/) `v2.0.1` or above.
+If you want to run the game locally, make sure following applications already installed in your machine:
+
+- [Docker](https://docs.docker.com/get-docker/) `v20.10.23` or above
+- [Docker Compose](https://docs.docker.com/compose/install/) `v2.0.1` or above
+- [make](https://linuxhint.com/make-command-linux/)
 
 After that use this command to run the game:
 
@@ -100,7 +102,7 @@ For details on these commands, please refer to [this Makefile](./Makefile).
 
 > **Note:**
 >
-> When we use [Hexagonal Architecture](./docs/reference/hex-architecture.md) to build a system, it is quite easy to swap its infrastructure code with another technologies.
+> When we use [Hexagonal Architecture](./docs/reference/hex-architecture.md) to build an application, it is quite easy to swap its infrastructure code with another technologies.
 >
 > So for example, if initially we used in-memory storage to store our data, we could easily swap it with MySQL storage or something else. This is why in this project we provide `3` variants of game server for you, this is to demonstrate exactly this point.
 

--- a/docs/reference/hex-architecture.md
+++ b/docs/reference/hex-architecture.md
@@ -84,8 +84,6 @@ In Solutions Team, we use following method spot out `Core` components:
 >
 > Sometimes we face confusion when we are in step `5`, `6`, & `7`. Usually this is because we find it difficult to find relationship between each `Core` components. In such case, try to utilize class diagram just like what we did in [here](../diagrams/class-diagram.png). This will greatly help us in mapping out the relationship between each `Core` components.
 
-[Back to Top](#hexagonal-architecture)
-
 ## Actors
 
 Actors are external entities interact with our application.
@@ -101,8 +99,6 @@ There are `2` types of actors:
 
 In the case of `Hex Monscape`, the incoming HTTP requests are the examples of `Driver Actor` while the `MySQL` database is the example of `Driven Actor`.
 
-[Back to Top](#hexagonal-architecture)
-
 ## Ports
 
 Ports are interfaces defined inside [Core](#core) that define how [Actors](#actors) can interact with [Core](#core) components & vice versa.
@@ -116,8 +112,6 @@ In the case of `Hex Monscape`, the examples for `Driver Ports` are [`battle.Serv
 
 As for the examples for `Driven Ports` are all interfaces defined in [here](../../internal/core/service/battle/storage.go) & [here](../../internal/core/service/play/storage.go).
 
-[Back to Top](#hexagonal-architecture)
-
 ## Adapters
 
 Adapters are the components used to translate interaction from [Actors](#actors) to [Core](#core) components & vice versa. They implements [Ports](#ports) defined in the [Core](#core).
@@ -130,8 +124,6 @@ There are `2` types of adapters:
 In the case of `Hex Monscape`, the example for `Driver Adapters` is [`rest.API`](../../internal/driver/rest/api.go).
 
 As for the examples for `Driven Adapters` are [`battlestrg.Storage`](../../internal/driven/storage/memory/battlestrg/storage.go), [`gamestrg.Storage`](../../internal/driven/storage/memory/gamestrg/storage.go), & [`monstrg.Storage`](../../internal/driven/storage/memory/monstrg/storage.go).
-
-[Back to Top](#hexagonal-architecture)
 
 ## Conclusion
 
@@ -151,8 +143,6 @@ This is why in Solutions Team we choose `Hexagonal Architecture` as our default 
 
 To learn how to apply `Hexagonal Architecture` in the new Solutions Team project, please refer to [Project Methodology](./project-methodology.md) document.
 
-[Back to Top](#hexagonal-architecture)
-
 ## Extra: Relation with DDD
 
 `Domain-Driven Design` (`DDD`) & `Hexagonal Architecture` is commonly paired together. Some people even used the terms interchangeably.
@@ -163,8 +153,6 @@ In reality, `DDD` & `Hexagonal Architecture` are two separate things. `DDD` is a
 
 `DDD` & `Hexagonal Architecture` is good combination when we want to create large application with complex business logic. But for us who want to create small application with simple business logic, `DDD` might be an overkill.
 
-[Back to Top](#hexagonal-architecture)
-
 ## References
 
 - https://alistair.cockburn.us/hexagonal-architecture/
@@ -173,5 +161,3 @@ In reality, `DDD` & `Hexagonal Architecture` are two separate things. `DDD` is a
 - https://medium.com/@matiasvarela/hexagonal-architecture-in-go-cfd4e436faa3
 - https://medium.com/ssense-tech/hexagonal-architecture-there-are-always-two-sides-to-every-story-bc0780ed7d9c
 - https://medium.com/ssense-tech/domain-driven-design-everything-you-always-wanted-to-know-about-it-but-were-afraid-to-ask-a85e7b74497a
-
-[Back to Top](#hexagonal-architecture)


### PR DESCRIPTION
Changes summary:

- Make [system requirements](https://github.com/Haraj-backend/hex-monscape/blob/40c0f0c175bc6f039a5c42f242e93e400a53934f/README.md?plain=1#L95-L97) in `README.md` as list so it could be read much easier.
- Fix link to `rest-api.md` in `README.md`.
- Completely remove `Back to Top` link from `hex-architecture.md` since it has no uses.
- Fix typos in `hex-architecture.md` by @5alidz.
- Tried to prevent `run-tests.yml` from running when we only push changes to the docs. However this is not possible due to bug on Github Action. The details could be seen [here](https://github.com/Haraj-backend/hex-monscape/pull/38/files#r1258950666).
- Add `Core Maintainers` section to increase repo credibility in `README.md`.