### PR TITLE
Chore: Fix Run `go mod tidy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vscode
 **/*.DS_Store
-tmp
+.tmp

--- a/build/package/server/.air.toml
+++ b/build/package/server/.air.toml
@@ -1,9 +1,9 @@
 root = "."
-tmp_dir = "tmp/air"
+tmp_dir = ".tmp/air"
 
 [build]
-  bin = "./tmp/air/server"
-  cmd = "go build -o ./tmp/air/server ./cmd/server/*.go"
+  bin = "./.tmp/air/server"
+  cmd = "go build -o ./.tmp/air/server ./cmd/server/*.go"
   delay = 1000
   exclude_dir = ["tmp", "vendor", "docs", "deploy"]
   exclude_file = []

--- a/build/package/server/Dockerfile
+++ b/build/package/server/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20.5-alpine3.18 as build
 WORKDIR /go/src/github.com/Haraj-backend/hex-monscape
 
 RUN go install github.com/cosmtrek/air@v1.44.0
-RUN mkdir -p tmp
+RUN mkdir -p .tmp
 
 COPY go.mod go.sum ./
 RUN go mod download -x

--- a/deploy/local/run/lambda/docker-compose.yml
+++ b/deploy/local/run/lambda/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ../../../../internal:/go/src/github.com/Haraj-backend/hex-monscape/internal
       - ../../../../cmd/lambda:/go/src/github.com/Haraj-backend/hex-monscape/cmd/lambda
-      - ../../../../tmp/go/pkg:/go/pkg
+      - ../../../../.tmp/go/pkg:/go/pkg
     environment:
       - LOCALSTACK_ENDPOINT=http://localstack:4566
       - DYNAMODB_BATTLE_TABLE=battle

--- a/deploy/local/run/rest-dynamodb/docker-compose.yml
+++ b/deploy/local/run/rest-dynamodb/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     volumes:
       - ../../../../internal:/go/src/github.com/Haraj-backend/hex-monscape/internal
       - ../../../../cmd/server:/go/src/github.com/Haraj-backend/hex-monscape/cmd/server
-      - ../../../../tmp/go/pkg:/go/pkg
+      - ../../../../.tmp/go/pkg:/go/pkg
     environment:
       - STORAGE_TYPE=dynamodb
       - STORAGE_DYNAMODB_LOCALSTACK_ENDPOINT=http://localstack:4566

--- a/deploy/local/run/rest-memory/docker-compose.yml
+++ b/deploy/local/run/rest-memory/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ../../../../internal:/go/src/github.com/Haraj-backend/hex-monscape/internal
       - ../../../../cmd/server:/go/src/github.com/Haraj-backend/hex-monscape/cmd/server
-      - ../../../../tmp/go/pkg:/go/pkg
+      - ../../../../.tmp/go/pkg:/go/pkg
       - ./data.json:/data/data.json
     ports:
       - 9186:9186

--- a/deploy/local/run/rest-mysql/docker-compose.yml
+++ b/deploy/local/run/rest-mysql/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ../../../../internal:/go/src/github.com/Haraj-backend/hex-monscape/internal
       - ../../../../cmd/server:/go/src/github.com/Haraj-backend/hex-monscape/cmd/server
-      - ../../../../tmp/go/pkg:/go/pkg
+      - ../../../../.tmp/go/pkg:/go/pkg
     ports:
       - 9186:9186
     environment:

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/Haraj-backend/hex-monscape
 go 1.18
 
 require (
+	github.com/Rican7/conjson v0.1.0
+	github.com/apex/gateway v1.1.2
 	github.com/aws/aws-sdk-go v1.44.162
 	github.com/go-chi/chi/v5 v5.0.7
+	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/render v1.0.1
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.3.0
@@ -15,12 +18,9 @@ require (
 )
 
 require (
-	github.com/Rican7/conjson v0.1.0 // indirect
-	github.com/apex/gateway v1.1.2 // indirect
 	github.com/aws/aws-lambda-go v1.17.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-chi/cors v1.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
If we run `go mod tidy` after `make run`, then we will get following error:

```
github.com/Haraj-backend/hex-monscape/tmp/go/pkg/mod/github.com/go-chi/render@v1.0.1: import path "github.com/Haraj-backend/hex-monscape/tmp/go/pkg/mod/github.com/go-chi/render@v1.0.1" should not have @version
github.com/Haraj-backend/hex-monscape/tmp/go/pkg/mod/gopkg.in/validator.v2@v2.0.0-20210331031555-b37d688a7fb0: import path "github.com/Haraj-backend/hex-monscape/tmp/go/pkg/mod/gopkg.in/validator.v2@v2.0.0-20210331031555-b37d688a7fb0" should not have @version
```

This is because we put `/go/pkg` cache inside `tmp` folder when running `air`.

So the solution to solve this is to rename the `tmp` folder into `.tmp`. I got this solutions from [here](https://stackoverflow.com/questions/57629849/stop-the-go-mod-tool-from-parsing-certain-directories).