### PR TITLE
Fix: Error 409 When Starting Battle using Rest Memory Variant

### DIFF
--- a/internal/driven/storage/memory/battlestrg/storage.go
+++ b/internal/driven/storage/memory/battlestrg/storage.go
@@ -11,7 +11,12 @@ type Storage struct {
 }
 
 func (s *Storage) GetBattle(ctx context.Context, gameID string) (*entity.Battle, error) {
-	b := s.data[gameID]
+	b, exist := s.data[gameID]
+	if !exist {
+		// if item is not found, returns nil as expected by battle interface
+		return nil, nil
+	}
+
 	return &b, nil
 }
 

--- a/internal/driven/storage/memory/battlestrg/storage_test.go
+++ b/internal/driven/storage/memory/battlestrg/storage_test.go
@@ -16,12 +16,17 @@ func TestSaveGetBattle(t *testing.T) {
 	strg := battlestrg.New()
 	expBattle := newBattle()
 
+	// get battle, supposedly the returned battle is nil
+	battle, err := strg.GetBattle(context.Background(), expBattle.GameID)
+	require.NoError(t, err)
+	require.Nil(t, battle, "battle is not nil")
+
 	// save battle
-	err := strg.SaveBattle(context.Background(), *expBattle)
+	err = strg.SaveBattle(context.Background(), *expBattle)
 	require.NoError(t, err)
 
 	// get battle
-	battle, err := strg.GetBattle(context.Background(), expBattle.GameID)
+	battle, err = strg.GetBattle(context.Background(), expBattle.GameID)
 	require.NoError(t, err)
 
 	// ensure battle is equal to expBattle

--- a/internal/driven/storage/memory/gamestrg/storage.go
+++ b/internal/driven/storage/memory/gamestrg/storage.go
@@ -11,7 +11,12 @@ type Storage struct {
 }
 
 func (s *Storage) GetGame(ctx context.Context, gameID string) (*entity.Game, error) {
-	g := s.data[gameID]
+	g, exist := s.data[gameID]
+	if !exist {
+		// if item is not found, returns nil as expected by game interface
+		return nil, nil
+	}
+
 	return &g, nil
 }
 

--- a/internal/driven/storage/memory/gamestrg/storage_test.go
+++ b/internal/driven/storage/memory/gamestrg/storage_test.go
@@ -16,12 +16,17 @@ func TestSaveGetGame(t *testing.T) {
 	strg := gamestrg.New()
 	expGame := initNewGame()
 
+	// get game, supposedly the returned game is nil
+	game, err := strg.GetGame(context.Background(), expGame.ID)
+	require.NoError(t, err)
+	require.Nil(t, game, "game is not nil")
+
 	// save game
-	err := strg.SaveGame(context.Background(), *expGame)
+	err = strg.SaveGame(context.Background(), *expGame)
 	require.NoError(t, err)
 
 	// get game
-	game, err := strg.GetGame(context.Background(), expGame.ID)
+	game, err = strg.GetGame(context.Background(), expGame.ID)
 	require.NoError(t, err)
 
 	// ensure game is equal to newGame


### PR DESCRIPTION
When I run the system using `make run` command & start a new game, it prevents me from starting a battle like this:

![Screenshot 2024-07-18 at 07 02 32](https://github.com/user-attachments/assets/3e6245dd-9842-43cd-851d-7e43be08a0a6)

Yet, the scenario status is correct, which is `BATTLE_1`:

![Screenshot 2024-07-18 at 07 03 15](https://github.com/user-attachments/assets/24c5dbd6-5f56-4e4a-a158-574517a44bdc)

Upon investigation, I found that the current implementation of `GetBattle()` in memory battle storage is not returning nil but an empty object when the service interface expects it to return nil. So, I fix this in this PR.

I also noticed the `GetGame()` implementation in memory game storage is in the same situation, so I fixed it in this PR.